### PR TITLE
fix: include name of sender in SMS confirmation email

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,4 +1,6 @@
 class NotifyMailer < ApplicationMailer
+  include NumberHelpers
+
   def rsvp(rsvp, type, old_seats)
     @rsvp = rsvp
     @old_seats = old_seats
@@ -19,8 +21,17 @@ class NotifyMailer < ApplicationMailer
   end
 
   def text_message(sender, body)
-    @sender = sender
     @body = body
+
+    formatted_phone_number = phone_number_formatted(sender)
+
+    rsvp = RSVP.where(phone_number: formatted_phone_number).last
+
+    if rsvp.nil?
+      @sender = sender
+    else
+      @sender = "#{sender} (#{rsvp.full_name})"
+    end
 
     mail(to: Settings.invites_from,
          subject: "SMS from #{@sender}",

--- a/app/models/concerns/number_helpers.rb
+++ b/app/models/concerns/number_helpers.rb
@@ -4,4 +4,18 @@ module NumberHelpers
   def phone_number_twilio
     "+1#{phone_number.gsub(/[^0-9]+/, '')}" if phone_number.present?
   end
+
+  def phone_number_formatted(number)
+    # ignore non-North American phone numbers
+    return number if number.size != 12 and number[0..1] != "+1"
+
+    # strip off +1
+    number = number[2..]
+
+    area_code = number[0..2]
+    exchange = number[3..5]
+    sln = number[6..9]
+
+    "(#{area_code}) #{exchange}-#{sln}"
+  end
 end


### PR DESCRIPTION
## Description
Include name of sender in SMS confirmation email.