### PR TITLE
fix: add unconfirmed RSVPs task; prevent extraneous notifications

### DIFF
--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -101,6 +101,9 @@ class RSVP < ApplicationRecord
     # don't notify of any RSVPs when notify is empty
     return if Settings.notify_rsvp.empty?
 
+    # don't notify if nothing changed about the RSVP
+    return if saved_changes.empty?
+
     # don't notify of new "no" RSVPs when notify is "yes" only
     return if Settings.notify_rsvp == "yes" and response != "yes" and previously_new_record?
 

--- a/lib/tasks/next_show.rake
+++ b/lib/tasks/next_show.rake
@@ -124,15 +124,15 @@ namespace :next_show do
     declines = 0
     RSVP.where(show: show).order(:id).each do |rsvp|
       if rsvp.confirmed?
-        is_confirmed = "✔"
+        status = "✔"
       elsif rsvp.waitlisted?
-        is_confirmed = "w"
+        status = "w"
       elsif rsvp.yes?
-        is_confirmed = "✖"
+        status = "✖"
       else
-        is_confirmed = " "
+        status = " "
       end
-      puts "#{rsvp.created_at.to_date} #{rsvp.response.rjust(3)}#{is_confirmed} #{rsvp.seats_reserved} #{rsvp.email}"
+      puts "#{rsvp.created_at.to_date} #{rsvp.response.rjust(3)}#{status} #{rsvp.seats_reserved} #{rsvp.email}"
 
       seats_reserved += rsvp.seats_reserved
       reservations += 1 if rsvp.yes?


### PR DESCRIPTION
## Description
- add `next_show:unconfirmed` rake task
- don't generate a confirmation email if nothing changed about the RSVP (i.e. someone hit save a second time)