### PR TITLE
fix: only add nonsubscribers who RSVPd yes

### DIFF
--- a/lib/tasks/people.rake
+++ b/lib/tasks/people.rake
@@ -1,6 +1,6 @@
 def find_nonsubscribers
   show = Show.occurred.last
-  rsvps = RSVP.where(show: show).where("email NOT IN (SELECT email FROM people)")
+  rsvps = RSVP.where(show: show, response: "yes").where("email NOT IN (SELECT email FROM people)")
   puts "Found #{rsvps.size} who RSVPd for #{show.name} and are not subscribed"
   rsvps
 end


### PR DESCRIPTION
## Description
only add nonsubscribers who RSVPd yes — avoids accidentally adding people who RSVPd no but weren't on the list.