### PR TITLE
fix: RSVP CLI output and notification email improvements

### DIFF
--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -33,6 +33,8 @@ class RSVP < ApplicationRecord
   validates :response, inclusion: { in: Settings.rsvp.response }
   validates :show_id, inclusion: { in: ->(_) { Show.all.collect(&:id) } }
 
+  RSVP_NOTIFY_ATTRIBUTES = %w[first_name last_name seats_reserved response].freeze
+
   def update_confirmation_date
     return if !confirmed_changed? || !confirmed?
 
@@ -101,8 +103,8 @@ class RSVP < ApplicationRecord
     # don't notify of any RSVPs when notify is empty
     return if Settings.notify_rsvp.empty?
 
-    # don't notify if nothing changed about the RSVP
-    return if saved_changes.empty?
+    # don't notify if nothing important changed (seats, response, name) about the RSVP
+    return if saved_changes.to_a.intersection(RSVP_NOTIFY_ATTRIBUTES).empty?
 
     # don't notify of new "no" RSVPs when notify is "yes" only
     return if Settings.notify_rsvp == "yes" and response != "yes" and previously_new_record?

--- a/lib/tasks/next_show.rake
+++ b/lib/tasks/next_show.rake
@@ -134,7 +134,7 @@ namespace :next_show do
       end
       puts "#{rsvp.created_at.to_date} #{rsvp.response.rjust(3)}#{status} #{rsvp.seats_reserved} #{rsvp.email}"
 
-      seats_reserved += rsvp.seats_reserved
+      seats_reserved += rsvp.seats_reserved if rsvp.yes?
       reservations += 1 if rsvp.yes?
       declines += 1 if rsvp.no?
       if rsvp.confirmed?


### PR DESCRIPTION
## Description
* don't count "no" RSVPs towards seats reserved in CLI output
* don't notify admin if RSVP is re-submitted without meaningful changes