### PR TITLE
fix: don’t filter email from log on local dev

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,3 +6,9 @@
 Rails.application.config.filter_parameters += %i[
   passw secret token _key crypt salt certificate otp ssn cvv cvc
 ]
+
+unless defined?(Rails::Console) or Rails.env.development?
+  Rails.application.config.filter_parameters += [
+    :email
+  ]
+end


### PR DESCRIPTION
## Description
Don’t filter email from log on local dev. this was lost in Rails 8 migration.
