### PR TITLE
fix: allow ruby 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "~> 4.0.5"
+ruby ">= 3.3.0"
 
 gem "mysql2"
 gem "rails", "~> 8"


### PR DESCRIPTION
## Description
Ubuntu still doesn't have ruby 4.