### PR TITLE
fix: secure auto-approve workflow for pull requests

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,12 +1,17 @@
 name: Auto approve
 
-on: pull_request_target
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - uses: hmarr/auto-approve-action@v4
+      - uses: hmarr/auto-approve-action@8f929096a962e83ccdfa8afcf855f39f12d4dac7


### PR DESCRIPTION
## Description
secure auto-approve workflow for pull requests
- don't use pull_request_target
- don't use github.actor
- use commit hash